### PR TITLE
Updating FreeAgentResourceOwner.php to account for FreeAgent response…

### DIFF
--- a/src/clients/freeagent/provider/FreeAgentResourceOwner.php
+++ b/src/clients/freeagent/provider/FreeAgentResourceOwner.php
@@ -17,17 +17,17 @@ class FreeAgentResourceOwner implements ResourceOwnerInterface
 
     public function getId()
     {
-        return $this->getValueByKey($this->response, 'id');
+        return $this->getValueByKey($this->response, 'user.url');
     }
 
     public function getName()
     {
-        return $this->getValueByKey($this->response, 'name');
+        return $this->getValueByKey($this->response, 'user.name');
     }
 
     public function getEmail()
     {
-        return $this->getValueByKey($this->response, 'email');
+        return $this->getValueByKey($this->response, 'user.email');
     }
 
     public function toArray()


### PR DESCRIPTION
… structure

There is no 'id' in Freeagent's models, they use instead a unique "URL" which acts as an id.