### PR TITLE
Few fixes to the Amazon Cognito Provider

### DIFF
--- a/src/clients/amazoncognito/provider/AmazonCognito.php
+++ b/src/clients/amazoncognito/provider/AmazonCognito.php
@@ -210,11 +210,11 @@ class AmazonCognito extends AbstractProvider
     /**
      * @param array $response
      * @param AccessToken $token
-     * @return CognitoUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
+     * @return AmazonCognitoUser|\League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
-        $user = new CognitoUser($response);
+        $user = new AmazonCognitoUser($response);
 
         return $user;
     }

--- a/src/providers/AmazonCognito.php
+++ b/src/providers/AmazonCognito.php
@@ -3,6 +3,7 @@ namespace verbb\auth\providers;
 
 use verbb\auth\base\ProviderTrait;
 use verbb\auth\clients\amazoncognito\provider\AmazonCognito as AmazonCognitoProvider;
+use verbb\auth\models\Token;
 
 class AmazonCognito extends AmazonCognitoProvider
 {
@@ -15,7 +16,7 @@ class AmazonCognito extends AmazonCognitoProvider
     // Public Methods
     // =========================================================================
 
-    public function getBaseApiUrl(): ?string
+    public function getBaseApiUrl(?Token $token): ?string
     {
         return 'https://api.amazon.com/';
     }


### PR DESCRIPTION
Fixes the following issues

- Missing token param in Provider's `getBaseApiUrl` function
- Client tried to instantiate a `CognitoUser`, not an `AmazonCognitoUser`