### PR TITLE
Update oauth2-client dependency with refresh token fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.20 - Unreleased
+- Update `league/oauth2-client` dependency with refresh token fix. Provides official compatibility with PHP 8.3 and 8.4
+
 ## 2.0.19 - 2025-01-03
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "verbb/auth",
     "description": "A Craft CMS module to make working with authentication for third-parties a breeze.",
-    "version": "2.0.19",
+    "version": "2.0.20",
     "support": {
         "email": "support@verbb.io",
         "issues": "https://github.com/verbb/auth/issues?state=open",
@@ -23,7 +23,7 @@
         "jakeasmith/http_build_url": "^1.0",
         "lcobucci/jwt": "^3.4 || ^4.0",
         "league/oauth1-client": "^1.9",
-        "league/oauth2-client": "2.7.0",
+        "league/oauth2-client": "^2.8.1",
         "mollie/mollie-api-php": "^1.19 || ^2.39",
         "paragonie/random-lib": "^2.0",
         "psr/http-message": "^1.0 || ^2.0",


### PR DESCRIPTION
The `oauth2-client` package has reverted the changes that broke refresh tokens. It should be now to safe to allow the package to update through composer.

In addition, since 2.8.0, this technically provides PHP 8.4 compatibility, which if verbb/auth remains locked to 2.7.0 could eventually cause issues for those wanting to use PHP 8.4