### PR TITLE
Update `pkceVerifier` check logic

### DIFF
--- a/src/clients/twitter/provider/Twitter.php
+++ b/src/clients/twitter/provider/Twitter.php
@@ -46,7 +46,7 @@ class Twitter extends AbstractProvider
      */
     public function getPkceVerifier(): string
     {
-        if (!isset($this->pkceVerifier)) {
+        if (!$this->pkceVerifier) {
             $this->pkceVerifier = $this->generatePkceVerifier();
         }
 


### PR DESCRIPTION
`pkceVerifier` is set in this point and equal to the empty string (default value). Unable to authorize X app with empty pkceVerifier bucause of the error `Missing required parameter [code_verifier].” /var/www/html/vendor/verbb/auth/src/providers/Twitter.php:61`